### PR TITLE
Fix specificContent/specificContentToNotExist content validation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+<a name="2.0.0"></a>
+## 2.0.0 (2018-09-21)
+
+* Changed specificContentToNotExist to specificValueToNotExist to be more consistent
+* Implemented checks for specificContent option

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Testing framwork for @hmcts/one-per-page",
   "homepage": "https://github.com/hmcts/one-per-page-test-suite#readme",
   "main": "./index.js",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmcts/one-per-page-test-suite.git"

--- a/src/content.js
+++ b/src/content.js
@@ -49,9 +49,21 @@ const content = (step, session, options = {}) => {
               contentExists.push(value);
             }
           });
-        if (contentExists.legnth) {
+        if (contentExists.length) {
           expect(contentExists, 'The following content was found in template when it wasnt supposed to be').to.eql([]);
         }
+      }
+
+      if (options.specificContent.length) {
+        const missingContent = [];
+        options.specificContent
+          .forEach(key => {
+            if (pageContent.indexOf(contentKeys[key]) === -1) {
+              missingContent.push(key);
+            }
+          });
+
+        return expect(missingContent, 'The following content was not found in template').to.eql([]);
       }
 
       if (!options.specificValues.length) {

--- a/src/content.js
+++ b/src/content.js
@@ -17,7 +17,7 @@ const content = (step, session, options = {}) => {
   options.ignoreContent = options.ignoreContent || [];
   options.specificContent = options.specificContent || [];
   options.specificValues = options.specificValues || [];
-  options.specificContentToNotExist = options.specificContentToNotExist || [];
+  options.specificValuesToNotExist = options.specificValuesToNotExist || [];
 
   options.ignoreContent.push('fields', 'errors');
 
@@ -41,9 +41,9 @@ const content = (step, session, options = {}) => {
     .get()
     .expect(httpStatus.OK)
     .text((pageContent, contentKeys) => {
-      if (options.specificContentToNotExist.length) {
+      if (options.specificValuesToNotExist.length) {
         const contentExists = [];
-        options.specificContentToNotExist
+        options.specificValuesToNotExist
           .forEach(value => {
             if (pageContent.indexOf(value) !== -1) {
               contentExists.push(value);

--- a/steps/index.js
+++ b/steps/index.js
@@ -1,0 +1,4 @@
+// needed for tests
+module.exports = () => {
+  return [];
+};

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -54,18 +54,18 @@ describe(modulePath, () => {
     });
   });
 
-  describe('specificContentToNotExist option', () => {
+  describe('specificValuesToNotExist option', () => {
     it('checks specified value is not present', () => {
       return content(SampleStep, {}, {
         ignoreContent: ['missingValue'],
-        specificContentToNotExist: ['blah']
+        specificValuesToNotExist: ['blah']
       });
     });
 
     it('fails if specified content is present', () => {
       return expect(content(SampleStep, {}, {
         ignoreContent: ['missingValue'],
-        specificContentToNotExist: ['page title']
+        specificValuesToNotExist: ['page title']
       }))
         .to
         .be

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -1,0 +1,75 @@
+const modulePath = 'src/content';
+
+const content = require(modulePath);
+const SampleStep = require('./steps/Sample.step');
+const chai = require('chai');
+
+const expect = chai.expect;
+
+describe(modulePath, () => {
+  describe('ignoreContent option', () => {
+    it('ignores specified content', () => {
+      return content(SampleStep, {}, { ignoreContent: ['missingValue'] });
+    });
+
+    it('checks specified content to be present but ignores others', () => {
+      return expect(content(SampleStep, {}, {
+        specificContent: ['title'],
+        ignoreContent: ['missingValue']
+      }));
+    });
+
+    it('fails if content is missing (and not ignored)', () => {
+      return expect(content(SampleStep, {}, {}))
+        .to
+        .be
+        .rejectedWith(Error);
+    });
+  });
+
+
+  describe('specificValues option', () => {
+    it('checks specified value to be present', () => {
+      return content(SampleStep, {}, { specificValues: ['hello'] });
+    });
+
+    it('fails if specified value is not present', () => {
+      return expect(content(SampleStep, {}, { specificValues: ['blah'] }))
+        .to
+        .be
+        .rejectedWith(Error);
+    });
+  });
+
+  describe('specificContent option', () => {
+    it('checks specified value to be present', () => {
+      return content(SampleStep, {}, { specificContent: ['title'] });
+    });
+
+    it('fails if specified content is not present', () => {
+      return expect(content(SampleStep, {}, { specificContent: ['blah'] }))
+        .to
+        .be
+        .rejectedWith(Error);
+    });
+  });
+
+  describe('specificContentToNotExist option', () => {
+    it('checks specified value is not present', () => {
+      return content(SampleStep, {}, {
+        ignoreContent: ['missingValue'],
+        specificContentToNotExist: ['blah']
+      });
+    });
+
+    it('fails if specified content is present', () => {
+      return expect(content(SampleStep, {}, {
+        ignoreContent: ['missingValue'],
+        specificContentToNotExist: ['page title']
+      }))
+        .to
+        .be
+        .rejectedWith(Error);
+    });
+  });
+});

--- a/test/steps/Sample.step.js
+++ b/test/steps/Sample.step.js
@@ -1,0 +1,9 @@
+const { ExitPoint } = require('@hmcts/one-per-page');
+
+class SampleStep extends ExitPoint {
+  static get path() {
+    return '/';
+  }
+}
+
+module.exports = SampleStep;

--- a/test/steps/SampleStep.content.json
+++ b/test/steps/SampleStep.content.json
@@ -1,0 +1,6 @@
+{
+  "en": {
+    "title": "page title",
+    "missingValue": "expected to be missing from template"
+  }
+}

--- a/test/steps/SampleStep.html
+++ b/test/steps/SampleStep.html
@@ -1,0 +1,4 @@
+
+{{ content.title }}
+
+{{ 'hello' }}

--- a/views/filters/index.js
+++ b/views/filters/index.js
@@ -1,0 +1,4 @@
+// needed for tests
+module.exports = () => {
+  return [];
+};


### PR DESCRIPTION
# Description

* Fixed typo preventing specificContentToNotExist from working properly
* Added support for checking specificContent to exist in view
* Added tests for all options (and accompanying files/sample view)

Fixes #7 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Added unit tests for all scenarios

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
