### PR TITLE
Fixed incorrect check of specificContent keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="2.0.1"></a>
-## 2.0.0 (2018-09-21)
+## 2.0.1 (2018-09-21)
 
 * Fix incorrect check for specificContent option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="2.0.1"></a>
+## 2.0.0 (2018-09-21)
+
+* Fix incorrect check for specificContent option
+
 <a name="2.0.0"></a>
 ## 2.0.0 (2018-09-21)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Testing framwork for @hmcts/one-per-page",
   "homepage": "https://github.com/hmcts/one-per-page-test-suite#readme",
   "main": "./index.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmcts/one-per-page-test-suite.git"

--- a/src/content.js
+++ b/src/content.js
@@ -58,7 +58,7 @@ const content = (step, session, options = {}) => {
         const missingContent = [];
         options.specificContent
           .forEach(key => {
-            if (pageContent.indexOf(contentKeys[key]) === -1) {
+            if (!contentKeys.hasOwnProperty(key)) {
               missingContent.push(key);
             }
           });


### PR DESCRIPTION
# Description

Previously, contentKeys[key] was returning undefined, which meant pageContent.indexOf was always true

Fixes #8 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on a project which makes use of this 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
