### PR TITLE
Test nested content keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Testing framwork for @hmcts/one-per-page",
   "homepage": "https://github.com/hmcts/one-per-page-test-suite#readme",
   "main": "./index.js",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmcts/one-per-page-test-suite.git"

--- a/src/content.js
+++ b/src/content.js
@@ -3,6 +3,7 @@ const govukTemplate = require('@hmcts/look-and-feel/src/sources/govukTemplate');
 const lookAndFeel = require('@hmcts/look-and-feel/src/sources/lookAndFeel');
 const { expect } = require('../utils/chai');
 const httpStatus = require('http-status-codes');
+const { get } = require('lodash');
 
 const templates = [
   govukTemplate.paths.templates,
@@ -59,7 +60,8 @@ const content = (step, session, options = {}) => {
         const missingContent = [];
         options.specificContent
           .forEach(key => {
-            if (!contentKeys.hasOwnProperty(key)) {
+            const contentValue = get(contentKeys, key);
+            if (pageContent.indexOf(contentValue) === -1) {
               missingContent.push(key);
             }
           });

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -31,16 +31,17 @@ describe(modulePath, () => {
 
   describe('specificValues option', () => {
     it('checks specified value to be present', () => {
-      return content(SampleStep, {}, { specificValues: ['hello'] });
+      const session = { myString: 'session value' };
+      return content(SampleStep, session, { specificValues: ['hello', 'session value'] });
     });
 
     it('fails if specified value is not present', () => {
-      return expect(content(SampleStep, {}, { specificValues: ['blah'] }))
+      return expect(content(SampleStep, {}, { specificValues: ['blah', 'session value'] }))
         .to
         .be
         .rejectedWith(Error);
     });
-    
+
     const params = ['hello', 'page title'];
     itParam('checks param value ${value} to be present', params, param => {
       return content(SampleStep, {}, { specificValues: [param] });
@@ -49,7 +50,7 @@ describe(modulePath, () => {
 
   describe('specificContent option', () => {
     it('checks specified value to be present', () => {
-      return content(SampleStep, {}, { specificContent: ['title'] });
+      return content(SampleStep, {}, { specificContent: ['title', 'nested.depth.heading', 'dynamicContent'] });
     });
 
     it('fails if specified content is not present', () => {

--- a/test/steps/Sample.step.js
+++ b/test/steps/Sample.step.js
@@ -1,8 +1,12 @@
-const { ExitPoint } = require('@hmcts/one-per-page');
+const { Question } = require('@hmcts/one-per-page');
 
-class SampleStep extends ExitPoint {
+class SampleStep extends Question {
   static get path() {
     return '/';
+  }
+
+  get session() {
+    return this.req.session;
   }
 }
 

--- a/test/steps/SampleStep.content.json
+++ b/test/steps/SampleStep.content.json
@@ -1,6 +1,12 @@
 {
   "en": {
     "title": "page title",
-    "missingValue": "expected to be missing from template"
+    "missingValue": "expected to be missing from template",
+    "nested": {
+      "depth": {
+        "heading": "nested depth rendering test"
+      }
+    },
+    "dynamicContent": "{{ session.myString }}"
   }
 }

--- a/test/steps/SampleStep.html
+++ b/test/steps/SampleStep.html
@@ -2,3 +2,7 @@
 {{ content.title }}
 
 {{ 'hello' }}
+
+{{ content.nested.depth.heading }}
+
+{{ content.dynamicContent }}


### PR DESCRIPTION
# Description

This allows users of OPPTS to query `content()` to see if a nested key from the content JSON is being used. See unit tests for examples.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
