### PR TITLE
Return skips the next conditions to check

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -67,7 +67,7 @@ const content = (step, session, options = {}) => {
             }
           });
 
-        return expect(contentExists, 'The following content should not be in the template').to.eql([]);
+        expect(contentExists, 'The following content should not be in the template').to.eql([]);
       }
 
       if (options.specificContent.length) {
@@ -80,7 +80,7 @@ const content = (step, session, options = {}) => {
             }
           });
 
-        return expect(missingContent, 'The following content was not found in template').to.eql([]);
+        expect(missingContent, 'The following content was not found in template').to.eql([]);
       }
 
       if (!options.specificValues.length) {
@@ -92,7 +92,7 @@ const content = (step, session, options = {}) => {
             }
           });
 
-        return expect(missingContent, 'The following content was not found in template').to.eql([]);
+        expect(missingContent, 'The following content was not found in template').to.eql([]);
       }
 
       const missingValues = [];
@@ -103,7 +103,7 @@ const content = (step, session, options = {}) => {
           }
         });
 
-      return expect(missingValues, 'The following values were not found in template').to.eql([]);
+       expect(missingValues, 'The following values were not found in template').to.eql([]);
     });
 };
 

--- a/src/content.js
+++ b/src/content.js
@@ -16,6 +16,7 @@ const templates = [
 ];
 
 const content = (step, session, options = {}) => {
+  const optionsNotGivenTestAllContent = Object.keys(options).length === 0;
   options.ignoreContent = options.ignoreContent || [];
   options.specificContent = options.specificContent || [];
   options.specificValues = options.specificValues || [];
@@ -83,7 +84,19 @@ const content = (step, session, options = {}) => {
         expect(missingContent, 'The following content was not found in template').to.eql([]);
       }
 
-      if (!options.specificValues.length) {
+      if (options.specificValues.length) {
+        const missingValues = [];
+        options.specificValues
+          .forEach(value => {
+            if (pageContent.indexOf(value) === -1) {
+              missingValues.push(value);
+            }
+          });
+  
+         expect(missingValues, 'The following values were not found in template').to.eql([]);
+      }
+
+      if (optionsNotGivenTestAllContent || options.ignoreContent.length > 2) {
         const missingContent = [];
         removeIgnoredContent(contentKeys)
           .forEach(key => {
@@ -94,16 +107,6 @@ const content = (step, session, options = {}) => {
 
         expect(missingContent, 'The following content was not found in template').to.eql([]);
       }
-
-      const missingValues = [];
-      options.specificValues
-        .forEach(value => {
-          if (pageContent.indexOf(value) === -1) {
-            missingValues.push(value);
-          }
-        });
-
-       expect(missingValues, 'The following values were not found in template').to.eql([]);
     });
 };
 


### PR DESCRIPTION
# Description

If we try to check below test, Even though specificContent does not exists the test will pass because of return statement in specificContentToNotExist check.

"content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });"

Changed the content test code to match below criteria:
If options are given,  test content only for the options else test complete page content
