### PR TITLE
Revert hyphen to dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@hmcts/eslint-config": "^1.3.0",
     "@hmcts/look-and-feel": "^1.19.6",
-    "@hmcts/one-per-page": "^4.0.7",
+    "@hmcts/one-per-page": "^5.0.0",
     "@hmcts/tech-docs": "^0.4.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "description": "Testing framwork for @hmcts/one-per-page",
   "homepage": "https://github.com/hmcts/one-per-page-test-suite#readme",
   "main": "./index.js",
+<<<<<<< HEAD
   "version": "2.0.22",
+=======
+  "version": "3.0.0",
+>>>>>>> revert hyphen for dots
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmcts/one-per-page-test-suite.git"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
   "description": "Testing framwork for @hmcts/one-per-page",
   "homepage": "https://github.com/hmcts/one-per-page-test-suite#readme",
   "main": "./index.js",
-<<<<<<< HEAD
-  "version": "2.0.22",
-=======
   "version": "3.0.0",
->>>>>>> revert hyphen for dots
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hmcts/one-per-page-test-suite.git"

--- a/src/question.js
+++ b/src/question.js
@@ -97,7 +97,7 @@ const rendersValues = (step, sessionData = {}, session = {}) => {
     .expect(httpStatus.OK)
     .html($ => {
       Object.keys(sessionData).forEach(key => {
-        expect($(`#${key}-${sessionData[key]}`)).has.$val(sessionData[key]);
+        expect($(`#${key}.${sessionData[key]}`)).has.$val(sessionData[key]);
       });
     });
 };

--- a/src/question.js
+++ b/src/question.js
@@ -97,7 +97,7 @@ const rendersValues = (step, sessionData = {}, session = {}) => {
     .expect(httpStatus.OK)
     .html($ => {
       Object.keys(sessionData).forEach(key => {
-        expect($(`#${key}.${sessionData[key]}`)).has.$val(sessionData[key]);
+        expect($(`#${key.replace(/\./g, '\\\.')}-${sessionData[key]}`)).has.$val(sessionData[key]);
       });
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,10 +159,10 @@
     webpack "^3.4.1"
     webpack-dev-middleware "^2.0.4"
 
-"@hmcts/one-per-page@^4.0.7":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@hmcts/one-per-page/-/one-per-page-4.1.2.tgz#77d9546a7c5238d18a9023dc38f8324ea59c83a5"
-  integrity sha512-EYWBt2hSQBHolOjf04NWrrVlTGH1A79Hx1H7Rf4d5z6jliFepobARkzu345Fg6bNdWYzr+ALEBj2YH1uQhr7sA==
+"@hmcts/one-per-page@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/one-per-page/-/one-per-page-5.0.0.tgz#431d5f398d49979d3d755271154db385081d455c"
+  integrity sha512-5Km56R1iJIq6fMj9Cje+K/2G9OGmqYFyhSwJdwPlzVVZIb+nGVvnCVixfVXxy9Ei3fdv9G4V5w3a4EusB3/sSA==
   dependencies:
     "@log4js-node/log4js-api" "^1.0.0"
     body-parser "^1.18.2"
@@ -185,7 +185,9 @@
     nunjucks "^3.0.1"
     option "^0.2.4"
     router "^1.3.2"
+    sanitizer "^0.1.3"
     slug "^0.9.2"
+    traverse "^0.6.6"
     url-parse "^1.4.3"
 
 "@hmcts/tech-docs@^0.4.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -8929,6 +8929,11 @@ samsam@1.3.0:
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
   integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
 
+sanitizer@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/sanitizer/-/sanitizer-0.1.3.tgz#d4f0af7475d9a7baf2a9e5a611718baa178a39e1"
+  integrity sha1-1PCvdHXZp7ryqeWmEXGLqheKOeE=
+
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -10066,6 +10071,11 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
An earlier change to replace dots for hyphen's broke some existing OPP functionality. This PR resolves it.